### PR TITLE
Enable multi arch docker image build

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
  
 env:
-  DOCKER_TAG_IMAGE: "ghcr.io/github/pages-gem"
+  REGISTRY: ghcr.io
 
 jobs:
   build:
@@ -17,19 +17,27 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Get Docker Metadata
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.DOCKER_TAG_IMAGE }}
+          images: ${{ env.REGISTRY }}/${{ github.repository }}
 
-      - name: Build Docker Image
-        run: |
-          docker build -t ${{ steps.meta.outputs.tags }} -f Dockerfile .
-
-      - name: Push to Container Registry
-        if: github.event_name != 'pull_request'
-        run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login -u ${{ github.actor }} https://ghcr.io --password-stdin
-          docker push ${{ steps.meta.outputs.tags }}
-
+      - name: Build Docker Image and Push to Container Registry
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
I figured the docker image is only build for amd64 architectures. 

With this change, multi arch is enabled by using the official docker build actions for docker login, build & push.